### PR TITLE
Add small note about ItemsAdder

### DIFF
--- a/docs/nova/admin/setup.md
+++ b/docs/nova/admin/setup.md
@@ -113,6 +113,9 @@ resource_pack:
 !!! info
 
     You can add as many base packs as you want.
+    
+    **Note:** When adding ItemsAdder items, blocks, etc. make sure to have created the pack before using `/iazip`.  
+    Otherwise important files may be missing from the final resource pack!
 
 
 !!! warning


### PR DESCRIPTION
Added a small note about ItemsAdder being required to have being `/iazip`ed before merging to avoid missing files.

I do not know how it is with other custom item plugins.