### PR TITLE
Slightly imprive ItemsAdder compat page

### DIFF
--- a/docs/nova/admin/compatibility/itemsadder.md
+++ b/docs/nova/admin/compatibility/itemsadder.md
@@ -2,9 +2,11 @@
 
 To make ItemsAdder and Nova work together, you need to follow these steps:
 
-1. Disable your current auto hoster in the ItemsAdder config and enable `no-host`.
-2. Add the ItemsAdder resource pack zip file as a [base pack](../setup.md#optional-resourcepack-merging) in Nova's main config.
-3. Regenerate Nova's resource pack with `/nova resourcePack create` (make sure that you've run `/iazip` before and the resource pack zip exists)
+1. Set the following values in the ItemsAdder `config.yml`:
+    - `resource_pack.hosting.no-host.enabled` is set to `true` (All other options under hosting must be false).
+    - `resource_pack.zip.protect-file-from-unzip.enabled` is set to `false` (Otherwise Zip exceptions will happen).
+3. Add the ItemsAdder resource pack zip file as a [base pack](../setup.md#optional-resourcepack-merging) in Nova's main config.
+4. Regenerate Nova's resource pack with `/nova resourcePack create` (make sure that you've run `/iazip` before and the resource pack zip exists)
 
 ## Adding new assets to ItemsAdder
 


### PR DESCRIPTION
A minor issue exists where Nova will throw an error when IA has zip-protection active (default).

This is now mentioned in the instructions.