### PR TITLE
Update Minecraft Wiki links to new domain after fork

### DIFF
--- a/docs/nova/addon/advancements.md
+++ b/docs/nova/addon/advancements.md
@@ -6,7 +6,7 @@ After creating all advancements, you can register them using `AdvancementManager
 !!! important
 
     Before continuing, make sure to be familiar with
-    [Minecraft's advancement format](https://minecraft.fandom.com/wiki/Advancement/JSON_format) which is used in datapacks,
+    [Minecraft's advancement format](https://minecraft.wiki/w/Advancement/JSON_format) which is used in datapacks,
     as Nova's way of registering advancements is basically just a kotlin DSL builder for that.
 
 ## Creating the root advancement

--- a/docs/nova/addon/asset-packs/language-files.md
+++ b/docs/nova/addon/asset-packs/language-files.md
@@ -3,7 +3,7 @@
 Everything in Nova has to be localized which is why language files are very important. To start off, create a folder
 called``lang`` in your ``assets`` root folder. Here you can create language files for your addon. The format for these
 files is the same the one minecraft uses. If you need the locale code for a language, you can search for
-it [here](https://minecraft.fandom.com/wiki/Language).
+it [here](https://minecraft.wiki/w/Language).
 
 !!! warning
 

--- a/docs/nova/addon/hitboxes.md
+++ b/docs/nova/addon/hitboxes.md
@@ -4,7 +4,7 @@ Nova provides you with two built-in ways to handle left- and right-click detecti
 
 ### PhysicalHitbox
 
-A `PhysicalHitbox` uses an [Interaction Entity](https://minecraft.fandom.com/wiki/Interaction).
+A `PhysicalHitbox` uses an [Interaction Entity](https://minecraft.wiki/w/Interaction).
 This means that the hitbox can be shown by pressing `F3+B` and functions similar to a normal entity, with it
 not allowing to interact with anything behind it.
 `PhysicalHitboxes` are also restricted to a square base area, as they only have a `width` and a `height`.

--- a/docs/nova/addon/items/item-behaviors.md
+++ b/docs/nova/addon/items/item-behaviors.md
@@ -58,7 +58,7 @@ Item behaviors are used to add functionality to items. There are some default im
             ```
 
             1. The type of the effect.  
-               A list of all effect types can be found [here](https://minecraft.fandom.com/wiki/Effect#Effect_list).
+               A list of all effect types can be found [here](https://minecraft.wiki/w/Effect#Effect_list).
             2. The duration of the effect in ticks.
             3. The amplifier of the effect. An amplifier of 0 is a level 1 effect.
             4. Whether the effect is ambient or not.  
@@ -84,7 +84,7 @@ Item behaviors are used to add functionality to items. There are some default im
         ```
 
         If you need some examples for the `armor`, `armorToughness` and `knockback_resistance` values,
-        you can check out the [Minecraft wiki](https://minecraft.fandom.com/wiki/Armor#Defense_points).
+        you can check out the [Minecraft wiki](https://minecraft.wiki/w/Armor#Defense_points).
 
     === "Tool"
     

--- a/docs/nova/addon/overlays/actionbar.md
+++ b/docs/nova/addon/overlays/actionbar.md
@@ -6,7 +6,7 @@
 Overlays follow the same concept of using fonts to render images as [GUI Textures](../guitexture.md), but are
 a bit more difficult to implement for addon developers, as you need to create the font file yourself.
 
-Font files are stored under `assets/fonts/` and have [this format](https://minecraft.fandom.com/wiki/Resource_Pack#Fonts).  
+Font files are stored under `assets/fonts/` and have [this format](https://minecraft.wiki/w/Resource_Pack#Fonts).  
 You might also want to take a look at [our font for the jetpack energy bar overlay](https://github.com/Nova-Addons/Jetpacks/blob/main/src/main/resources/assets/fonts/energy_bar.json).
 
 ## ActionBarOverlay

--- a/docs/nova/addon/worldgen/biome.md
+++ b/docs/nova/addon/worldgen/biome.md
@@ -8,7 +8,7 @@
 
 Biomes are regions in the world with distinct [features](features/features.md), [carvers](carver.md), [climate](#climate),
 [effects](#special-effects) and much more. This page only covers the `BiomeBuilder` for now. If you're looking for the Json
-format, check out the [Minecraft Wiki](https://minecraft.fandom.com/wiki/Custom_biome).
+format, check out the [Minecraft Wiki](https://minecraft.wiki/w/Custom_biome).
 
 First, let's get into more detail on the individual components of a biome.
 

--- a/docs/nova/addon/worldgen/carver.md
+++ b/docs/nova/addon/worldgen/carver.md
@@ -5,4 +5,4 @@
     This worldgen page is still a work in progress. Some Json formats/code examples/features might be missing and will be
     added in the future.
 
-TODO - Check out the [Minecraft Wiki](https://minecraft.fandom.com/wiki/Custom_carver) in the meantime.
+TODO - Check out the [Minecraft Wiki](https://minecraft.wiki/w/Custom_carver) in the meantime.

--- a/docs/nova/addon/worldgen/features/configurations/ores.md
+++ b/docs/nova/addon/worldgen/features/configurations/ores.md
@@ -90,7 +90,7 @@ The following `RuleTests` are available:
     </tr>
     <tr>
         <td><code>minecraft:tag_match</code></td>
-        <td>Matches a specific <a href="https://minecraft.fandom.com/wiki/Tag#Blocks">block tag</a></td>
+        <td>Matches a specific <a href="https://minecraft.wiki/w/Tag#Blocks">block tag</a></td>
         <td>
             ```kotlin
             TagMatchTest(BlockTags.STONE_ORE_REPLACEABLES)

--- a/docs/nova/addon/worldgen/features/features.md
+++ b/docs/nova/addon/worldgen/features/features.md
@@ -6,7 +6,7 @@ Most features are registered in 3 "steps":
 ### 1. Feature Type
 
 The feature type is the logic behind the feature. It's the only part that needs to be written in code. Minecraft already
-has a ton of default feature types (Although they're just called `Feature` in NMS). Check out the [Minecraft Wiki](https://minecraft.fandom.com/wiki/Custom_feature#Feature_Type)
+has a ton of default feature types (Although they're just called `Feature` in NMS). Check out the [Minecraft Wiki](https://minecraft.wiki/w/Custom_feature#Feature_Type)
 for an up-to-date list of all feature types.
 
 ### 2. Configured Feature

--- a/docs/nova/addon/worldgen/features/placed-feature.md
+++ b/docs/nova/addon/worldgen/features/placed-feature.md
@@ -210,7 +210,7 @@ Returns the given position `count` times.
 
 ### `minecraft:count_on_every_layer`
 
-**Deprecated**. For more information, check out the [Minecraft Wiki](https://minecraft.fandom.com/wiki/Custom_feature#count_on_every_layer)
+**Deprecated**. For more information, check out the [Minecraft Wiki](https://minecraft.wiki/w/Custom_feature#count_on_every_layer)
 
 ### `minecraft:environment_scan`
 

--- a/docs/nova/addon/worldgen/types/block-predicate.md
+++ b/docs/nova/addon/worldgen/types/block-predicate.md
@@ -5,4 +5,4 @@
     This worldgen page is still a work in progress. Some Json formats/code examples/features might be missing and will be
     added in the future.
 
-TODO - Check out the [Minecraft Wiki](https://minecraft.fandom.com/wiki/Custom_world_generation/block_predicate) in the meantime.
+TODO - Check out the [Minecraft Wiki](https://minecraft.wiki/w/Custom_world_generation/block_predicate) in the meantime.

--- a/docs/nova/addon/worldgen/types/block-state-provider.md
+++ b/docs/nova/addon/worldgen/types/block-state-provider.md
@@ -5,4 +5,4 @@
     This worldgen page is still a work in progress. Some Json formats/code examples/features might be missing and will be
     added in the future.
 
-TODO - Check out the [Minecraft Wiki](https://minecraft.fandom.com/wiki/Custom_world_generation/block_state_provider) in the meantime.
+TODO - Check out the [Minecraft Wiki](https://minecraft.wiki/w/Custom_world_generation/block_state_provider) in the meantime.

--- a/docs/nova/addon/worldgen/types/block-state.md
+++ b/docs/nova/addon/worldgen/types/block-state.md
@@ -5,4 +5,4 @@
     This worldgen page is still a work in progress. Some Json formats/code examples/features might be missing and will be
     added in the future.
 
-TODO - Check out the [Minecraft Wiki](https://minecraft.fandom.com/wiki/Custom_world_generation/block_state) in the meantime.
+TODO - Check out the [Minecraft Wiki](https://minecraft.wiki/w/Custom_world_generation/block_state) in the meantime.

--- a/docs/nova/addon/worldgen/types/number-provider.md
+++ b/docs/nova/addon/worldgen/types/number-provider.md
@@ -7,8 +7,8 @@
 
 ## `IntProvider`
 
-TODO - Check out the [Minecraft Wiki](https://minecraft.fandom.com/wiki/Configured_feature/int_provider) in the meantime.
+TODO - Check out the [Minecraft Wiki](https://minecraft.wiki/w/Configured_feature/int_provider) in the meantime.
 
 ## `FloatProvider`
 
-TODO - Check out the [Minecraft Wiki](https://minecraft.fandom.com/wiki/Configured_feature/float_provider) in the meantime.
+TODO - Check out the [Minecraft Wiki](https://minecraft.wiki/w/Configured_feature/float_provider) in the meantime.

--- a/docs/nova/addon/worldgen/worldgen.md
+++ b/docs/nova/addon/worldgen/worldgen.md
@@ -1,6 +1,6 @@
 # World Generation Overview
 
-Nova's worldgen is completely based on [Minecraft's custom worldgen format](https://minecraft.fandom.com/wiki/Custom_world_generation) with
+Nova's worldgen is completely based on [Minecraft's custom worldgen format](https://minecraft.wiki/w/Custom_world_generation) with
 some additions. However, you can also register everything worldgen-related in code if you don't want to use Json. If you 
 do decide to use Json files, make sure to create a `data/worldgen` directory in your addon's resources folder before you 
 start. This is where all your worldgen files will be stored.

--- a/docs/nova/api/items/index.md
+++ b/docs/nova/api/items/index.md
@@ -83,7 +83,7 @@ Example for ``nova:wrench``:
 
 Nova uses the resource pack to translate items client side. However, if you still need to get the translated name of an item,
 you can use ``NovaItem.getLocalizedName(locale)``. The locale is the language code of the language you want to get the name in.
-The code is the same as the language code used by [Minecraft](https://minecraft.fandom.com/wiki/Language).
+The code is the same as the language code used by [Minecraft](https://minecraft.wiki/w/Language).
 
 !!! info
 


### PR DESCRIPTION
The Minecraft Wiki maintainers have decided to move away from Fandom. More information can be found here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates all the URLs to the new domain: minecraft.wiki