### PR TITLE
Update creating-items.md (":" between Items and ItemRegistry)

### DIFF
--- a/docs/nova/addon/items/creating-items.md
+++ b/docs/nova/addon/items/creating-items.md
@@ -19,7 +19,7 @@ You can register a really simple item like this:
 
 ```kotlin
 @Init(stage = InitStage.PRE_PACK)
-object Items ItemRegistry by ExampleAddon.registry {
+object Items : ItemRegistry by ExampleAddon.registry {
 
    val EXAMPLE_ITEM = registerItem("example_item", /* Item Behaviors */)
    
@@ -40,7 +40,7 @@ Nova offers a DSL builder for creating item model definitions:
 
 ```kotlin
 @Init(stage = InitStage.PRE_PACK)
-object Items ItemRegistry by ExampleAddon.registry {
+object Items : ItemRegistry by ExampleAddon.registry {
 
    val EXAMPLE_ITEM = item("example_item") {
       modelDefinition {


### PR DESCRIPTION
This commit just adds a : between Items and Itemregistry. It took me some time as a Kotlin beginner to figure out what was the problem in my code.

SUMMARY:
added : in code