### PR TITLE
Change `sweeping` to `sweeping_edge`

### DIFF
--- a/docs/nova/addon/items/enchantments.md
+++ b/docs/nova/addon/items/enchantments.md
@@ -17,7 +17,7 @@ supported_enchantments: # (2)!
    - minecraft:knockback
    - minecraft:fire_aspect
    - minecraft:looting
-   - minecraft:sweeping
+   - minecraft:sweeping_edge
    - minecraft:unbreaking
    - minecraft:mending
 ```


### PR DESCRIPTION
- Enchantment `minecraft:sweeping` has been renamed to `minecraft:sweeping_edge` since the version 1.20.5 ([Source](https://minecraft.wiki/w/Sweeping_Edge#History))
- Example configuration for item behavior `Enchantable` included the old enchantment name and produced an error, as no such enchantment could be found.

This PR changes the configuration entry and makes the code example valid again.